### PR TITLE
Add modular news source scrapers

### DIFF
--- a/catch_sources/__init__.py
+++ b/catch_sources/__init__.py
@@ -1,0 +1,27 @@
+"""Utility catchers for various news sources.
+
+Each module within this package exposes a ``catch_<source>`` function
+that returns a list of news items.  A news item is represented as a
+dictionary containing at least ``title`` and ``link`` keys.  The
+functions are designed to be resilient: if fetching or parsing fails,
+they simply return an empty list so that callers can continue
+processing other sources.
+"""
+
+from .catch_36kr import catch_36kr
+from .catch_IThome import catch_IThome
+from .catch_JQZX import catch_JQZX
+from .catch_QBitAI import catch_QBitAI
+from .catch_theverge import catch_theverge
+from . import catch_ProductHunt
+from .catch_ProductHunt import catch_producthunt
+
+__all__ = [
+    "catch_36kr",
+    "catch_IThome",
+    "catch_JQZX",
+    "catch_QBitAI",
+    "catch_theverge",
+    "catch_ProductHunt",
+    "catch_producthunt",
+]

--- a/catch_sources/catch_36kr.py
+++ b/catch_sources/catch_36kr.py
@@ -1,0 +1,32 @@
+"""Fetcher for 36氪 (36Kr) news."""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import List, Dict
+
+import feedparser
+
+
+def _parse_feed(url: str, days: int) -> List[Dict[str, str]]:
+    try:
+        feed = feedparser.parse(url)
+    except Exception:
+        return []
+
+    cutoff = _dt.datetime.utcnow() - _dt.timedelta(days=days)
+    items: List[Dict[str, str]] = []
+    for entry in feed.entries:
+        published = entry.get("published_parsed") or entry.get("updated_parsed")
+        if published:
+            dt = _dt.datetime(*published[:6])
+            if dt < cutoff:
+                continue
+        items.append({"title": entry.get("title", ""), "link": entry.get("link", "")})
+    return items
+
+
+def catch_36kr(days: int = 1) -> List[Dict[str, str]]:
+    """Return recent posts from 36氪 (36Kr)."""
+    url = "https://36kr.com/feed"
+    return _parse_feed(url, days)

--- a/catch_sources/catch_IThome.py
+++ b/catch_sources/catch_IThome.py
@@ -1,0 +1,32 @@
+"""Fetcher for IT之家 (ITHome) news."""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import List, Dict
+
+import feedparser
+
+
+def _parse_feed(url: str, days: int) -> List[Dict[str, str]]:
+    try:
+        feed = feedparser.parse(url)
+    except Exception:
+        return []
+
+    cutoff = _dt.datetime.utcnow() - _dt.timedelta(days=days)
+    items: List[Dict[str, str]] = []
+    for entry in feed.entries:
+        published = entry.get("published_parsed") or entry.get("updated_parsed")
+        if published:
+            dt = _dt.datetime(*published[:6])
+            if dt < cutoff:
+                continue
+        items.append({"title": entry.get("title", ""), "link": entry.get("link", "")})
+    return items
+
+
+def catch_IThome(days: int = 1) -> List[Dict[str, str]]:
+    """Return recent posts from IT之家."""
+    url = "https://www.ithome.com/rss/"
+    return _parse_feed(url, days)

--- a/catch_sources/catch_JQZX.py
+++ b/catch_sources/catch_JQZX.py
@@ -1,0 +1,32 @@
+"""Fetcher for 机器之心 (Machine Heart) news."""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import List, Dict
+
+import feedparser
+
+
+def _parse_feed(url: str, days: int) -> List[Dict[str, str]]:
+    try:
+        feed = feedparser.parse(url)
+    except Exception:
+        return []
+
+    cutoff = _dt.datetime.utcnow() - _dt.timedelta(days=days)
+    items: List[Dict[str, str]] = []
+    for entry in feed.entries:
+        published = entry.get("published_parsed") or entry.get("updated_parsed")
+        if published:
+            dt = _dt.datetime(*published[:6])
+            if dt < cutoff:
+                continue
+        items.append({"title": entry.get("title", ""), "link": entry.get("link", "")})
+    return items
+
+
+def catch_JQZX(days: int = 1) -> List[Dict[str, str]]:
+    """Return recent posts from 机器之心."""
+    url = "https://www.jiqizhixin.com/rss"
+    return _parse_feed(url, days)

--- a/catch_sources/catch_QBitAI.py
+++ b/catch_sources/catch_QBitAI.py
@@ -1,0 +1,32 @@
+"""Fetcher for 量子位 (QBitAI) news."""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import List, Dict
+
+import feedparser
+
+
+def _parse_feed(url: str, days: int) -> List[Dict[str, str]]:
+    try:
+        feed = feedparser.parse(url)
+    except Exception:
+        return []
+
+    cutoff = _dt.datetime.utcnow() - _dt.timedelta(days=days)
+    items: List[Dict[str, str]] = []
+    for entry in feed.entries:
+        published = entry.get("published_parsed") or entry.get("updated_parsed")
+        if published:
+            dt = _dt.datetime(*published[:6])
+            if dt < cutoff:
+                continue
+        items.append({"title": entry.get("title", ""), "link": entry.get("link", "")})
+    return items
+
+
+def catch_QBitAI(days: int = 1) -> List[Dict[str, str]]:
+    """Return recent posts from 量子位 (QBitAI)."""
+    url = "https://www.qbitai.com/feed"
+    return _parse_feed(url, days)

--- a/catch_sources/catch_theverge.py
+++ b/catch_sources/catch_theverge.py
@@ -1,0 +1,39 @@
+"""Fetch news from The Verge via its RSS feed."""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import List, Dict
+
+import feedparser
+
+
+def _parse_feed(url: str, days: int) -> List[Dict[str, str]]:
+    """Return entries from ``url`` published within ``days`` days."""
+    try:
+        feed = feedparser.parse(url)
+    except Exception:
+        return []
+
+    cutoff = _dt.datetime.utcnow() - _dt.timedelta(days=days)
+    items: List[Dict[str, str]] = []
+    for entry in feed.entries:
+        published = entry.get("published_parsed") or entry.get("updated_parsed")
+        if published:
+            dt = _dt.datetime(*published[:6])
+            if dt < cutoff:
+                continue
+        items.append({"title": entry.get("title", ""), "link": entry.get("link", "")})
+    return items
+
+
+def catch_theverge(days: int = 1) -> List[Dict[str, str]]:
+    """Return recent articles from The Verge.
+
+    Parameters
+    ----------
+    days: int
+        How many days back to fetch. Defaults to 1.
+    """
+    url = "https://www.theverge.com/rss/index.xml"
+    return _parse_feed(url, days)


### PR DESCRIPTION
## Summary
- Create `catch_sources` package to house individual news scrapers
- Implement scrapers for 36Kr, ITHome, JQZX, QBitAI, The Verge, and ProductHunt using RSS feeds
- Expose catch functions in package `__init__` for integration with existing `catch_news.py` and `crawl_test.py`

## Testing
- `python -m py_compile catch_sources/*.py`
- `python - <<'PY'
import catch_news
print('Running catch_all...')
print(catch_news.catch_all(days=0, english_source=True))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68afb9e16a40832cb6b80c5b32ca932d