### PR TITLE
feat: migrate to GPT-5 API

### DIFF
--- a/api_func.py
+++ b/api_func.py
@@ -1,18 +1,19 @@
-###################     GPT-4o    ###################
 from openai import OpenAI
 import requests
 
-def openai_4o_request(question):
+###################     GPT-5    ###################
+
+# 旧的 GPT-4o 与 mini 接口已停用
+
+def openai_5_request(question):
     client = OpenAI(
         # 将这里换成你在便携AI聚合API后台生成的令牌
         api_key='',
         # 这里将官方的接口访问地址替换成便携AI聚合API的入口地址
-        base_url="https://api.bianxie.ai/v1"
+        base_url="https://api.bianxie.ai/v1",
     )
     completion = client.chat.completions.create(
-        # model="chatgpt-4o-latest",
-        # model="gpt-4o-mini",
-        model = "gpt-4o",
+        model="gpt-5",
         temperature=0.5,
         messages=[
             {
@@ -21,66 +22,19 @@ def openai_4o_request(question):
             }
         ]
     )
-    result = {'answer' : completion.choices[0].message.content,'token_num' : completion.usage.completion_tokens}
+    result = {
+        'answer': completion.choices[0].message.content,
+        'token_num': completion.usage.completion_tokens
+    }
     return result['answer']
 
-def gpt_4o_mini_request(question):
-    client = OpenAI(
-        # 将这里换成你在便携AI聚合API后台生成的令牌
-        api_key='',
-        # 这里将官方的接口访问地址替换成便携AI聚合API的入口地址
-        base_url="https://api.bianxie.ai/v1"
-    )
-    completion = client.chat.completions.create(
-        # model="chatgpt-4o-latest",
-        model="gpt-4o-mini",
-        # model = "gpt-4o-2024-08-06",
-        temperature=0.5,
-        messages=[
-            {
-                "role": "user",
-                "content": question,
-            }
-        ]
-    )
-    result = {'answer' : completion.choices[0].message.content,'token_num' : completion.usage.completion_tokens}
-    return result['answer']
 
-# 在 openai_4o_request 和 gpt_4o_mini_request 函数之后，添加这个新函数
-def openai_41_request(question):
-    client = OpenAI(
-        # 将这里换成你在便携AI聚合API后台生成的令牌
-        api_key='',
-        # 这里将官方的接口访问地址替换成便携AI聚合API的入口地址
-        base_url="https://api.bianxie.ai/v1"
-     )
-    completion = client.chat.completions.create(
-        model = "gpt-4.1",  # 使用GPT-4.1模型
-        temperature=0.5,
-        messages=[
-            {
-                "role": "user",
-                "content": question,
-            }
-        ]
-    )
-    result = {'answer' : completion.choices[0].message.content,'token_num' : completion.usage.completion_tokens}
-    return result['answer']
-
-def gpt_request(question, choice = "4o"):  # 您可以保留默认值为"4o"或改为"41"
-    if choice == "4o":
-        return openai_4o_request(question)
-    elif choice == "41":  # 添加这个新的选项
-        return openai_41_request(question)
-    elif choice == "mini":
-        return gpt_4o_mini_request(question)
-    else:
-        return openai_4o_request(question)  # 或改为 openai_41_request(question)
+def gpt_request(question, choice="gpt5"):
+    return openai_5_request(question)
 
 
+###################     Claude3.5    ###################
 
-
-###################     Claude3.5    ################### 
 def claude_request(question):
     api_key = ''
     url = 'https://api.bianxie.ai/v1/chat/completions'
@@ -96,6 +50,4 @@ def claude_request(question):
     response = requests.post(url, headers=headers, json=data)
     result = response.json()['choices'][0]['message']['content']
     return result
-
-
 

--- a/ask_gpt.py
+++ b/ask_gpt.py
@@ -42,7 +42,7 @@ def main():
 
     # Create summary sections
     create_summary_section(paper_frame, "Paper Summary", func.summarize_paper)
-    create_summary_section(web_frame, "Web Content Summary", func.mini_4o_summarize_web)
+    create_summary_section(web_frame, "Web Content Summary", func.summarize_web)
     create_summary_section(product_frame, "Product Summary", func.summarize_product)
 
     # Run the application

--- a/crawl_test.py
+++ b/crawl_test.py
@@ -73,7 +73,7 @@ def rough_filter_batch(new_infos) -> list:
     info_titles = [f"{index}. {item['title']}" for index, item in enumerate(new_infos)]
     info_titles_text = '\n'.join(info_titles)
 
-    # 让gpt-4o筛选哪些titles是相关内容，输出索引号
+    # 让gpt-5筛选哪些titles是相关内容，输出索引号
     filtered_info_titles_index = func.title_filter_rough(info_titles_text)
 
     # 筛选出包含这些有用title的元素
@@ -190,7 +190,7 @@ def get_producthunt():
 
 
 # 用于将新闻玩家信息总结
-def write_news(new_doc, info_titles_final, info_titles2link, manual=False, choice='4o'):
+def write_news(new_doc, info_titles_final, info_titles2link, manual=False, choice='gpt5'):
     # 标准开头
     doc.add_title(new_doc, f'【ChatGPT全球动态日报{datetime.datetime.now().strftime("%m%d")}】 — TEG战略发展中心推送', level=1)
     doc.add_paragraph(new_doc, 'Dear all，')
@@ -242,7 +242,7 @@ def write_news(new_doc, info_titles_final, info_titles2link, manual=False, choic
 
 
 # 用于将论文信息总结
-def write_papers(new_doc, papers, manual=False, choice='4o'):
+def write_papers(new_doc, papers, manual=False, choice='gpt5'):
     doc.add_title(new_doc, '二、技术前沿分析', level=1)
 
     # 无论文
@@ -286,7 +286,7 @@ def write_papers(new_doc, papers, manual=False, choice='4o'):
     save_doc(new_doc, 'papers')
 
 
-def write_producthunt(new_doc, producthunt_items, manual=False, choice='4o'):
+def write_producthunt(new_doc, producthunt_items, manual=False, choice='gpt5'):
     doc.add_title(new_doc, '三、应用场景分析', level=1)
 
     if producthunt_items is None or len(producthunt_items) == 0:
@@ -340,7 +340,7 @@ def write_producthunt(new_doc, producthunt_items, manual=False, choice='4o'):
 
 
 def make_report(manual=False, paper_days=1, news_days=1,
-                makenews=True, makepapers=True, makeproduct=True, choice='4o'):
+                makenews=True, makepapers=True, makeproduct=True, choice='gpt5'):
     """
     生成报告（docx），并在最后把最终 docx 转为 HTML 字符串返回
     scheduler → send_email 会把该 HTML 作为邮件正文发送

--- a/make_report.py
+++ b/make_report.py
@@ -101,11 +101,10 @@ def main():
         # Choice section
         choice_frame = ttk.LabelFrame(root, text="Choice Options")
         choice_frame.pack(fill="x", padx=10, pady=10)
-        choice_var = tk.StringVar(value="4o")
+        choice_var = tk.StringVar(value="gpt5")
         choice_label = ttk.Label(choice_frame, text="Choice:")
         choice_label.pack(side="left", padx=10)
-        choice_var = tk.StringVar(value="")
-        choice_combobox = ttk.Combobox(choice_frame, textvariable=choice_var, values=["4o", "mini"],
+        choice_combobox = ttk.Combobox(choice_frame, textvariable=choice_var, values=["gpt5"],
                                        state="readonly")
         choice_combobox.pack(side="left", padx=10)
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -47,7 +47,7 @@ def generate_and_send_report():
         paper_days = 1 if datetime.datetime.now().weekday() != 1 else 3
         news_days = 2 if datetime.datetime.now().weekday() != 0 else 3
 
-        report_content = make_report(manual, paper_days, news_days, True, True, True, '4o')
+        report_content = make_report(manual, paper_days, news_days, True, True, True, 'gpt5')
 
         if not report_content:
             print("生成报告内容为空")


### PR DESCRIPTION
## Summary
- replace deprecated 4o and mini model calls with GPT-5
- update summarization and report generation tools to use GPT-5
- adjust UI defaults and scheduler to GPT-5
- guard news filtering helpers against missing code fences in GPT-5 responses

## Testing
- `python -m py_compile api_func.py functions.py ask_gpt.py make_report.py scheduler.py crawl_test.py`
- `python crawl_test.py` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68afbf4b2c5c832cafd95e2ccf316a78